### PR TITLE
Fix boolean command format

### DIFF
--- a/orangepi_backend/without_gui.py
+++ b/orangepi_backend/without_gui.py
@@ -166,7 +166,13 @@ class ESP32Monitor:
     
     def set_parameter(self, parameter: str, value: Any) -> bool:
         """Establecer un parámetro en el ESP32"""
-        command = f"CMD:SET_{parameter}:{value}"
+        # Convertir booleanos a 'true'/'false' para compatibilidad con el firmware
+        if isinstance(value, bool):
+            value_str = str(value).lower()
+        else:
+            value_str = str(value)
+
+        command = f"CMD:SET_{parameter}:{value_str}"
         response = self.send_command(command)
         
         if response and response.startswith("OK:"):


### PR DESCRIPTION
## Summary
- fix boolean value handling in without_gui command builder

## Testing
- `python3 -m py_compile orangepi_backend/without_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ba834b8c832b89cfdfe98edd8d85