### PR TITLE
Update dashboard to show float stage current limit

### DIFF
--- a/orangepi_backend/without_gui.py
+++ b/orangepi_backend/without_gui.py
@@ -320,6 +320,7 @@ def display_dashboard(data: Dict[str, Any]):
         ("Capacidad", format_value('ah', data.get('batteryCapacity'))),
         ("Umbral Corriente", format_value('percentage', data.get('thresholdPercentage'))),
         ("Corriente Máx", format_value('current', data.get('maxAllowedCurrent'))),
+        ("Límite Flotación", format_value('current', data.get('currentLimitIntoFloatStage'))),
         ("Factor Div", data.get('factorDivider')),
         ("Horas Bulk Máx", format_value('hours', data.get('maxBulkHours'))),
         ("Horas Abs Máx", format_value('hours', data.get('maxAbsorptionHours'))),


### PR DESCRIPTION
## Summary
- add `currentLimitIntoFloatStage` to battery parameters on terminal dashboard

## Testing
- `python3 -m py_compile orangepi_backend/without_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c0650644832bbc9705b764761a8e